### PR TITLE
Update to align naming with other sinks

### DIFF
--- a/src/Serilog.Sinks.Humio.Example/Program.cs
+++ b/src/Serilog.Sinks.Humio.Example/Program.cs
@@ -9,7 +9,7 @@ namespace Serilog.Sinks.Humio.Example
         {
             var log = new LoggerConfiguration()
                 .MinimumLevel.Information()
-                .WriteTo.HumioSink(new HumioSinkConfiguration
+                .WriteTo.Humio(new HumioSinkConfiguration
                 {
                     BatchSizeLimit = 50,
                     Period = TimeSpan.FromSeconds(5),

--- a/src/Serilog.Sinks.Humio/HumioSinkExtensions.cs
+++ b/src/Serilog.Sinks.Humio/HumioSinkExtensions.cs
@@ -4,7 +4,7 @@ namespace Serilog.Sinks.Humio
 {
     public static class HumioSinkExtensions
     {
-        public static LoggerConfiguration HumioSink(
+        public static LoggerConfiguration Humio(
                   this LoggerSinkConfiguration loggerConfiguration,
                   HumioSinkConfiguration sinkConfiguration)
         {


### PR DESCRIPTION
Other sinks don't have the `Sink` suffix in their extension methods. Just a suggestion.