### PR TITLE
add extension so init can be done from appsettings.json values.

### DIFF
--- a/src/Serilog.Sinks.Humio/HumioSinkExtensions.cs
+++ b/src/Serilog.Sinks.Humio/HumioSinkExtensions.cs
@@ -43,5 +43,31 @@ namespace Serilog.Sinks.Humio
                         Period = TimeSpan.FromSeconds(2)
                     }));
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="loggerConfiguration"></param>
+        /// <param name="ingestToken"></param>
+        /// <param name="url"></param>
+        /// <param name="batchSizeLimit"></param>
+        /// <param name="period"></param>
+        /// <returns></returns>
+        public static LoggerConfiguration HumioSink(
+                  this LoggerSinkConfiguration loggerConfiguration,
+                  string ingestToken, string url, int batchSizeLimit, TimeSpan period)
+        {
+            return loggerConfiguration.Sink(
+                new PeriodicBatchingSink(
+                    new HumioSink(new HumioSinkConfiguration
+                    {
+                        IngestToken = ingestToken,
+                        Url = url,
+                    }),
+                    new PeriodicBatchingSinkOptions
+                    {
+                        BatchSizeLimit = batchSizeLimit,
+                        Period = period
+                    }));
+        }
     }
 }


### PR DESCRIPTION
Make it possible to initialize the sink from config like this:

appsettings.json element:

    "Serilog": {
        "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File", "Serilog.Sinks.Humio" ],
        "MinimumLevel": {
            "Default": "Verbose",
            "Override": {
                "Microsoft": "Verbose",
                "Microsoft.Hosting.Lifetime": "Verbose"
            }
        },
        "WriteTo": [
            {
                "Name": "File",
                "Args": {
                    "path": "./logs/log-.txt",
                    "rollingInterval": "Day"
                }
            },
            {
                "Name": "Console",
                "Args": {
                }
            },
            {
                "Name": "HumioSink",
                "Args": {                    
                      "IngestToken": "token",
                      "Url": "https://cloud.community.humio.com",
                      "BatchSizeLimit": 50,
                      "Period": "0:00:05"                    
                }
            }
        ]
    },
    
In Startup:    

    var logger = new LoggerConfiguration()
                        .ReadFrom.Configuration(builder.Configuration)
                        .Enrich.FromLogContext()
                        .CreateLogger();